### PR TITLE
Fix typo in admin label comment

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -149,7 +149,7 @@ function admin_style() {
 }
 add_action('admin_enqueue_scripts', 'admin_style');
 
-//Change posts admin label to news in admin meny
+//Change posts admin label to news in admin menu
 function al_change_label() {
     global $menu;
     global $submenu;


### PR DESCRIPTION
## Summary
- fix comment typo referring to admin menu

## Testing
- `php -l functions.php`


------
https://chatgpt.com/codex/tasks/task_e_689b14d3ab148333abc1cd7d6873c648